### PR TITLE
add config for default broadcast & multicast policy

### DIFF
--- a/src/foomuuri
+++ b/src/foomuuri
@@ -56,6 +56,7 @@ CONFIG = {
     'set_size': '65535',
     'recursion_limit': '65535',
     'priority_offset': '5',
+    'cast_policy': 'drop',
     'dbus_firewalld': 'no',
     'nft_bin': 'nft',
 
@@ -1270,12 +1271,15 @@ def output_zone(zonemap, szone, dzone, rules, ipv):
     output_cast('multicast', szone, dzone, rules, ipv)
     if ipv == 4:
         output_cast('broadcast', szone, dzone, rules, ipv)
-        out('meta pkttype { broadcast, multicast } drop')
+        ptype = "{ broadcast, multicast }"
     else:
-        out('meta pkttype multicast drop')
+        ptype = " multicast "
+
+    out(f'meta pkttype {ptype} {CONFIG["cast_policy"]}')
 
     # Unicast
     output_cast('unicast', szone, dzone, rules, ipv)
+
     out('}')
 
 


### PR DESCRIPTION
I have foomuuri on a host which is running Home Assistant in podman. The default rule of

`meta pkttype { broadcast, multicast } drop`

means that Home Assistant cannot discover any devices on the lan even if the final rule for the zone is accept

so now I can add 
```
foomuuri {
  cast_policy 'accept'
}
````
in my config for this host, with this I can now enable all broadcast and multicast traffic on localhost-lan and lan-localhost to keep home assistant happy