### PR TITLE
default.services: add Salt service

### DIFF
--- a/etc/default.services.conf
+++ b/etc/default.services.conf
@@ -78,6 +78,7 @@ macro {
   rfb             vnc
   rsync           tcp 873
   rtsps           tcp 322
+  salt            tcp 4505 4506
   secure-mqtt     tcp 8883
   sieve           tcp 4190
   sip             udp 5060 helper sip-5060


### PR DESCRIPTION
Update default.service.conf to add TCP ports of Salt configuration management system.

Source: https://docs.saltproject.io/en/latest/topics/tutorials/firewall.html#opening-the-firewall-up-for-salt