### PR TITLE
Add connection timeout to iplist download

### DIFF
--- a/src/foomuuri
+++ b/src/foomuuri
@@ -3211,7 +3211,7 @@ def get_url(url):
                 time.sleep(10)
             try:
                 with requests.get(
-                    remove_filters(url), timeout=50, stream=True
+                    remove_filters(url), timeout=(6.1,50), stream=True
                 ) as response:
                     if response.status_code != 200:
                         raise requests.ConnectionError(


### PR DESCRIPTION
Adds separate connection timeout (3.05*3) as per recommendations for tcp timeouts to be slightly larger than multiple of 3.

Maybe makes sense to set it even lower, like 6.10. 3.05 would be pushing it I think.

Currently, without dedicated connection timeout, with existing combined timeout of 50 seconds, connection to unresponsive source hangs for almost 2 minutes before exception is raised.