### PR TITLE
Replace iplist cache dict comprehension with dict.fromkeys()

### DIFF
--- a/src/foomuuri
+++ b/src/foomuuri
@@ -3516,7 +3516,7 @@ def get_url_or_file(url, timeout, refresh, cache):
         # address lists.
         expire = now + timeout
         cache[url] = {
-            'ip': {addr: expire for addr in iplist_cleanup_file(url, value)},
+            'ip': dict.fromkeys(iplist_cleanup_file(url, value), expire),
             'dirty': True,
             'refresh': now,
         }


### PR DESCRIPTION
Benchmarking the change (kk's of repeated calls), dict.fromkeys() is ~6% quicker (py3.13).
```
>>> timeit.repeat('list({ip: 0 for ip in range(1000)})', repeat=1, number=100000)
[5.692549920640886]
>>> timeit.repeat('list(dict.fromkeys(range(1000),0))', repeat=1, number=100000)
[5.343623613938689]
```
Typical usage difference is negligible, but less cycles are less cycles.