### PR TITLE
Add str converter hook to config dataclass field

### DIFF
--- a/src/foomuuri
+++ b/src/foomuuri
@@ -161,11 +161,12 @@ class TypedConfig:
             raise TypeError(
                 f'{name}: expected value type {str}, got {type(value)}'
             )
-        target_type = self._get_field(name).type
+        field = self._get_field(name)
+        if converter := field.metadata.get('convert_str'):
+            value = converter(value)
+        target_type = field.type
         if target_type is int:
             value = int(value)
-        elif target_type is list and name.endswith('_bin'):
-            value = shlex.split(value)
         elif target_type is pathlib.PosixPath:
             value = pathlib.PosixPath(value)
         elif not isinstance(value, target_type):
@@ -216,7 +217,8 @@ class Config(TypedConfig):
         default='no', metadata={'validate': Validators.str_yes_no}
     )
     nft_bin: list = dataclasses.field(
-        default_factory=lambda: ['nft']
+            default_factory=lambda: ['nft'],
+            metadata={'convert_str': shlex.split}
     )
     try_reload_timeout: int = dataclasses.field(
         default=15,  metadata={'validate': Validators.int_positive}

--- a/src/tests/test_typed_config.py
+++ b/src/tests/test_typed_config.py
@@ -33,6 +33,9 @@ class TestTypedConfig(unittest.TestCase):
             validation_str: str = field(
                 init=False, metadata={'validate': lambda v: v != ''}
             )
+            conversion: list = field(
+                init=False, metadata={'convert_str': lambda v: v.split()}
+            )
 
         self.config = TestConfig()
 
@@ -100,9 +103,14 @@ class TestTypedConfig(unittest.TestCase):
         self.assertRaises(ValueError, self.assign, 'validation_str', '')
         self.assertEqual(self.assign('validation_str', 'test'), 'test')
 
+    def test_convert_str(self):
+        """Test attribute convert_str hook call."""
+        self.assertEqual(self.assign_from_str('conversion', 'a b'), ['a', 'b'])
+
     def test_iter(self):
         """Test __iter__."""
         self.assertEqual(sorted(self.config), [
+            'conversion',
             'initialized_str',
             'type_conversion_int',
             'type_conversion_list',


### PR DESCRIPTION
Pros:

- Doesn't mix implementation details with generic processing
- Conversion is obvious immediately when glancing over field definition, it's not performed indirectly somewhere else

Cons:

- Syntactic verbosity via field metadata definition