### PR TITLE
Add parse_command_line() unit tests

### DIFF
--- a/src/tests/test_parse_command_line.py
+++ b/src/tests/test_parse_command_line.py
@@ -1,0 +1,171 @@
+"""Basic unit tests of parse_command_line()."""
+# pylint: disable=invalid-name,import-error
+# ruff: noqa: N803
+
+import copy
+import unittest
+import unittest.mock
+
+from foomuuri import CONFIG as BASE_CONFIG
+from foomuuri import INTERNAL as BASE_INTERNAL
+from foomuuri import VERSION, parse_command_line
+
+
+@unittest.mock.patch('foomuuri.CONFIG_OVERRIDE', new_callable=dict)
+@unittest.mock.patch(
+    'foomuuri.CONFIG', new_callable=lambda: copy.deepcopy(BASE_CONFIG)
+)
+@unittest.mock.patch(
+    'foomuuri.INTERNAL', new_callable=lambda: copy.deepcopy(BASE_INTERNAL)
+)
+class TestParseCommandLine(unittest.TestCase):
+    """Test parse_command_line()."""
+    @unittest.mock.patch('sys.argv', ['foomuuri'])
+    def test_no_arguments(self, INTERNAL, *_):
+        """Test no arguments."""
+        parse_command_line()
+        self.assertEqual(INTERNAL.command, '')
+        self.assertEqual(INTERNAL.parameters, [])
+
+    @unittest.mock.patch('sys.argv', ['foomuuri', '--help'])
+    def test_option_help(self, INTERNAL, *_):
+        """Test --help option (sets 'help' command)."""
+        parse_command_line()
+        self.assertEqual(INTERNAL.command, 'help')
+        self.assertEqual(INTERNAL.parameters, [])
+
+    @unittest.mock.patch('sys.argv', ['foomuuri', '--version'])
+    @unittest.mock.patch('builtins.print')
+    def test_option_version(self, print_mock, *_):
+        """Test --version option (prints VERSION and exits)."""
+        self.assertRaises(SystemExit, parse_command_line)
+        print_mock.assert_called_with(VERSION)
+
+    @unittest.mock.patch(
+        'sys.argv',
+        ['foomuuri', '--verbose', 'command', 'arg1', '--force', 'arg2'],
+    )
+    def test_command_and_options(self, INTERNAL, CONFIG, CONFIG_OVERRIDE):
+        """Test command with arguments, mixed with options."""
+        parse_command_line()
+        self.assertEqual(INTERNAL.command, 'command')
+        self.assertEqual(INTERNAL.parameters, ['arg1', 'arg2'])
+        self.assertEqual(INTERNAL.force, 1)
+        self.assertEqual(CONFIG.verbose, 1)
+        self.assertEqual(CONFIG_OVERRIDE['verbose'], 1)
+
+    @unittest.mock.patch('sys.argv', ['foomuuri', '--syslog', '--fork'])
+    def test_options_syslog_fork(self, INTERNAL, CONFIG, CONFIG_OVERRIDE):
+        """Test --syslog and --fork options."""
+        parse_command_line()
+        self.assertEqual(CONFIG.syslog, 1)
+        self.assertEqual(CONFIG.fork, 1)
+        self.assertEqual(CONFIG_OVERRIDE['syslog'], 1)
+        self.assertEqual(CONFIG_OVERRIDE['fork'], 1)
+        self.assertEqual(INTERNAL.command, '')
+        self.assertEqual(INTERNAL.parameters, [])
+
+    @unittest.mock.patch('sys.argv', ['foomuuri', '--verbose'])
+    def test_option_verbose(self, INTERNAL, CONFIG, CONFIG_OVERRIDE):
+        """Test --verbose option."""
+        parse_command_line()
+        self.assertEqual(CONFIG.verbose, 1)
+        self.assertEqual(CONFIG_OVERRIDE['verbose'], 1)
+        self.assertEqual(INTERNAL.command, '')
+        self.assertEqual(INTERNAL.parameters, [])
+
+    @unittest.mock.patch('sys.argv', ['foomuuri', '--verbose', '--verbose'])
+    def test_options_verbose_verbose(self, INTERNAL, CONFIG, CONFIG_OVERRIDE):
+        """Test --verbose --verbose options."""
+        parse_command_line()
+        self.assertEqual(CONFIG.verbose, 2)
+        self.assertEqual(CONFIG_OVERRIDE['verbose'], 2)
+        self.assertEqual(INTERNAL.command, '')
+        self.assertEqual(INTERNAL.parameters, [])
+
+    @unittest.mock.patch('sys.argv', ['foomuuri', '--quiet'])
+    def test_option_quiet(self, INTERNAL, CONFIG, CONFIG_OVERRIDE):
+        """Test --quiet option."""
+        parse_command_line()
+        self.assertEqual(CONFIG.verbose, -1)
+        self.assertEqual(CONFIG_OVERRIDE['verbose'], -1)
+        self.assertEqual(INTERNAL.command, '')
+        self.assertEqual(INTERNAL.parameters, [])
+
+    @unittest.mock.patch('sys.argv', ['foomuuri', '--verbose', '--quiet'])
+    def test_options_verbose_quiet(self, INTERNAL, CONFIG, CONFIG_OVERRIDE):
+        """Test --verbose --quiet options."""
+        parse_command_line()
+        self.assertEqual(CONFIG.verbose, 0)
+        self.assertEqual(CONFIG_OVERRIDE['verbose'], 0)
+        self.assertEqual(INTERNAL.command, '')
+        self.assertEqual(INTERNAL.parameters, [])
+
+    @unittest.mock.patch('sys.argv', ['foomuuri', '--force'])
+    def test_option_force(self, INTERNAL, *_):
+        """Test --force option."""
+        parse_command_line()
+        self.assertEqual(INTERNAL.force, 1)
+        self.assertEqual(INTERNAL.command, '')
+        self.assertEqual(INTERNAL.parameters, [])
+
+    @unittest.mock.patch('sys.argv', ['foomuuri', '--soft'])
+    def test_option_soft(self, INTERNAL, *_):
+        """Test --soft option."""
+        parse_command_line()
+        self.assertEqual(INTERNAL.force, -1)
+        self.assertEqual(INTERNAL.command, '')
+        self.assertEqual(INTERNAL.parameters, [])
+
+    @unittest.mock.patch('sys.argv', ['foomuuri', '--set'])
+    @unittest.mock.patch('foomuuri.fail', side_effect=SystemExit)
+    def test_option_set_unknown(self, fail, *_):
+        """Test --set option without suffix."""
+        self.assertRaises(SystemExit, parse_command_line)
+        fail.assert_called_with('Unknown option: --set')
+
+    @unittest.mock.patch('sys.argv', ['foomuuri', '--set='])
+    @unittest.mock.patch('foomuuri.fail', side_effect=SystemExit)
+    def test_option_set_invalid_syntax(self, fail, *_):
+        """Test incomplete --set option syntax."""
+        self.assertRaises(SystemExit, parse_command_line)
+        fail.assert_called_with(
+            'Invalid syntax for --set=OPTION=VALUE: --set='
+        )
+
+    @unittest.mock.patch('sys.argv', ['foomuuri', '--set=unknown=value'])
+    @unittest.mock.patch('foomuuri.fail', side_effect=SystemExit)
+    def test_option_set_unknown_option(self, fail, *_):
+        """Test --set option with unknown foomuuri{} CONFIG option."""
+        self.assertRaises(SystemExit, parse_command_line)
+        fail.assert_called_with(
+            'Unknown foomuuri{} option: --set=unknown=value'
+        )
+
+    @unittest.mock.patch('sys.argv', ['foomuuri', '--set=priority_offset=yes'])
+    @unittest.mock.patch('foomuuri.fail', side_effect=SystemExit)
+    def test_option_set_invalid_value(self, fail, *_):
+        """Test --set option with invalid value."""
+        self.assertRaises(SystemExit, parse_command_line)
+        fail.assert_called_with(
+            'Invalid foomuuri{} option priority_offset value: yes'
+        )
+
+    @unittest.mock.patch(
+        'sys.argv',
+        ['foomuuri', '--set=priority_offset=42', '--set=set_size=1'],
+    )
+    def test_options_set_valid(self, INTERNAL, CONFIG, _):
+        """Test --set options with valid foomuuri{} CONFIG option/value."""
+        parse_command_line()
+        self.assertEqual(CONFIG.priority_offset, 42)
+        self.assertEqual(CONFIG.set_size, 1)
+        self.assertEqual(INTERNAL.command, '')
+        self.assertEqual(INTERNAL.parameters, [])
+
+    @unittest.mock.patch('sys.argv', ['foomuuri', '--unknown'])
+    @unittest.mock.patch('foomuuri.fail', side_effect=SystemExit)
+    def test_unknown_option(self, fail, *_):
+        """Test unknown option."""
+        self.assertRaises(SystemExit, parse_command_line)
+        fail.assert_called_with('Unknown option: --unknown')


### PR DESCRIPTION
It's a little bit verbose, but covers whole parse_command_line(). No more sudden functionality loss, I hope.