### PR TITLE
Target ruff to python 3.9, ignore FA100

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,3 +1,5 @@
+target-version = "py39"
+
 lint.select = [
     "ALL",
 ]
@@ -15,6 +17,7 @@ lint.ignore = [
     "EM101", # Exception must not use a string literal, assign to variable first
     "EM102", # Exception must not use an f-string literal, assign to variable first
     "ERA001", # Found commented-out code
+    "FA100", # Add `from __future__ import annotations` to simplify
     "FBT001", # Boolean-typed positional argument in function definition
     "FBT002", # Boolean default positional argument in function definition
     "FBT003", # Boolean positional value in function call


### PR DESCRIPTION
FA100 suggestion, `from __future__ import annotations`, while looking promising, changes dataclasses field type annotation (https://bugs.python.org/issue39442). It can be worked around with `typing.get_type_hints()`. Next failure point is unittest tests loader (raises exception in dataclasses internals).
At this point it's just not worth to spend any more time on it.