### PR TITLE
Add print_table() formatted table printer

### DIFF
--- a/src/foomuuri
+++ b/src/foomuuri
@@ -538,6 +538,45 @@ def verbose(line: str, level: int = 1) -> None:
             syslog.syslog(syslog.LOG_NOTICE, line)
 
 
+def print_table(
+    data: list[tuple],
+    align: str = '<',
+    header: bool = False,
+    sep: str = '   ',
+) -> None:
+    """Simplistic formatted table printer."""
+    if not data or (header and len(data) == 1):
+        return
+
+    if not set(align).issubset(set('^<>')):
+        raise ValueError('Supported alignment: left <, right >, center ^')
+
+    columns = len(data[0])
+    width = [
+        max(len(str(row[column])) for row in data) for column in range(columns)
+    ]
+
+    if len(align) == 1:
+        align *= columns
+    elif len(align) != columns:
+        raise ValueError('Align value does not match column count')
+
+    for r, row in enumerate(data):
+        print(
+            sep.join(
+                [
+                    f'{column:{align[c]}{width[c]}}'
+                    for c, column in enumerate(row)
+                ]
+            ),
+        )
+
+        if header and not r:
+            print(
+                sep.join([f'{"-" * width[c]}' for c in range(columns)]),
+            )
+
+
 def out(line: str) -> None:
     """Add single line to ruleset."""
     OUT.append(line)

--- a/src/foomuuri
+++ b/src/foomuuri
@@ -3512,13 +3512,15 @@ def command_status():
 
     print()
     print('zone {')
+    table = []
     for zone in zones:
         interfaces = [
             interface
             for interface, int_zones in zone_interface.items()
             if zone == int_zones
         ]
-        print(f'  {zone:15s} {" ".join(interfaces)}')
+        table.append(('', zone, f'{" ".join(interfaces)}'))
+    print_table(data=table, header=False)
     print('}')
     return 0
 

--- a/src/foomuuri
+++ b/src/foomuuri
@@ -4888,13 +4888,18 @@ def command_list() -> int:
     if list_type == 'macro':
         macros = parse_config_macros(read_config(require_etc_config=False))
         print('macro {')
-        for macro in sorted(macros):
-            if not macro.startswith('_template_') and (
+        table = [
+            ('', macro, f'{" ".join(macros[macro])}')
+            for macro in sorted(macros)
+            if not macro.startswith('_template_')
+            and (
                 not list_params
                 or macro in list_params
                 or any(item in list_params for item in macros[macro])
-            ):
-                print(f'  {macro:15s} {" ".join(macros[macro])}')
+            )
+        ]
+
+        print_table(data=table, header=False)
         print('}')
         return 0
 

--- a/src/foomuuri
+++ b/src/foomuuri
@@ -4854,6 +4854,8 @@ def list_named_counter(command):
     if not data:
         return 1
 
+    table = [('Counter', 'Packets', 'Bytes')]
+
     for toplevel in data.get('nftables', []):
         counter = toplevel.get('counter')
         name = (counter or {}).get('name')
@@ -4861,7 +4863,9 @@ def list_named_counter(command):
             continue
         packet_value = counter.get('packets', 0)
         byte_value = counter.get('bytes', 0)
-        print(f'{name:21s}  {packet_value} packets, {byte_value} bytes')
+        table.append((name, f'{packet_value}', f'{byte_value}'))
+
+    print_table(data=table, align='<>>', header=True)
     return 0
 
 

--- a/src/foomuuri
+++ b/src/foomuuri
@@ -4231,6 +4231,7 @@ def command_iplist_list():
     """List iplist entries."""
     config = minimal_config()
     known = parse_config_iplist(config)
+    table = [('Set', 'Element')]
     for setname in INTERNAL.parameters[1:] or sorted(known):
         setname = setname.removeprefix('@')
         if setname.endswith(('_4', '_6')):
@@ -4243,10 +4244,11 @@ def command_iplist_list():
         elem6 = [ipaddr for ipaddr, _dummy in iterate_set_elements(data6)]
         elems = sorted(elem4) + sorted(elem6)
         if not elems:
-            print(f'@{setname}')
+            table.append((f'@{setname}', ''))
         else:
-            for elem in elems:
-                print(f'@{setname:20s}  {elem}')
+            table.extend((f'@{setname}', elem) for elem in elems)
+
+    print_table(data=table, header=True)
     return 0
 
 

--- a/src/tests/test_print_table.py
+++ b/src/tests/test_print_table.py
@@ -1,0 +1,114 @@
+"""Basic unit tests of print_table()."""
+# pylint: disable=invalid-name,import-error
+# ruff: noqa: W291
+
+import io
+import unittest
+import unittest.mock
+
+from foomuuri import print_table
+
+
+@unittest.mock.patch('sys.stdout', new_callable=io.StringIO)
+class TestPrintTable(unittest.TestCase):
+    """Test print_table()."""
+
+    def setUp(self):
+        """Fill in common fixture values."""
+        self.data_multiple_rows = [
+            (
+                'row 1 column 1',
+                'row 1 colum 2',
+                'row 1 colu 3',
+            ),
+            (
+                'row 2 colu 1',
+                'row 2 colum 2',
+                'row 2 column 3',
+            ),
+        ]
+
+        self.data_no_rows = []
+
+        self.header = (
+            'Header',
+            'Long Elaborate Header',
+            'Medium Header',
+        )
+
+    def test_invalid_align_values(self, _):
+        """Test invalid align values."""
+        invalid_align = [
+            '',  # no alignment
+            'x',  # invalid align value
+            '<<',  # too few values for 3 columns
+            '<<<<',  # too much values for 3 columns
+        ]
+
+        for align in invalid_align:
+            with self.subTest(align):
+                self.assertRaises(
+                    ValueError,
+                    print_table,
+                    self.data_multiple_rows,
+                    align=align,
+                )
+
+    def test_print_table_all_args(self, stdout: io.StringIO):
+        """Test table with all supported arguments."""
+        print_table(
+            data=[self.header] + self.data_multiple_rows,
+            header=True,
+            align='<>^',
+            sep='    ',
+        )
+
+        self.assertEqual(
+            stdout.getvalue(),
+            """Header            Long Elaborate Header    Medium Header 
+--------------    ---------------------    --------------
+row 1 column 1            row 1 colum 2     row 1 colu 3 
+row 2 colu 1              row 2 colum 2    row 2 column 3
+""",
+        )
+
+    def test_print_table_with_rows_no_headers(self, stdout: io.StringIO):
+        """Test table without headers, rows only."""
+        print_table(data=self.data_multiple_rows)
+
+        self.assertEqual(
+            stdout.getvalue(),
+            """row 1 column 1   row 1 colum 2   row 1 colu 3  
+row 2 colu 1     row 2 colum 2   row 2 column 3
+""",
+        )
+
+    def test_print_table_no_rows(self, stdout: io.StringIO):
+        """Test table without headers and rows."""
+        print_table(data=self.data_no_rows)
+
+        self.assertEqual(
+            stdout.getvalue(),
+            '',
+        )
+
+    def test_print_table_with_headers_no_rows(self, stdout: io.StringIO):
+        """Test table with headers, without rows."""
+        print_table(data=[self.header] + self.data_no_rows, header=True)
+        self.assertEqual(
+            stdout.getvalue(),
+            '',
+        )
+
+    def test_print_table_default_align(self, stdout: io.StringIO):
+        """Test table with headers, and default (left) align."""
+        print_table(data=[self.header] + self.data_multiple_rows, header=True)
+
+        self.assertEqual(
+            stdout.getvalue(),
+            """Header           Long Elaborate Header   Medium Header 
+--------------   ---------------------   --------------
+row 1 column 1   row 1 colum 2           row 1 colu 3  
+row 2 colu 1     row 2 colum 2           row 2 column 3
+""",
+        )


### PR DESCRIPTION
Helper function to output tabular data in pretty, formatted way.

Table can have one or more columns, with optional headers.

Column width is adjusted automatically by max width of its elements
(including header).

Each column can be right, left (default) or center aligned.

Inter-column padding is also configurable (three spaces by default).