### PR TITLE
Fix inconsistency in install.md

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -114,8 +114,8 @@ tar xf foomuuri-0.??.tar.gz
 cd foomuuri-0.??
 
 # Install it to root filesystem
-sudo make install DESTDIR=/
-sudo systemctl daemon-reload
+make install DESTDIR=/
+systemctl daemon-reload
 
 # Configure Foomuuri and verify it
 $EDITOR /etc/foomuuri/foomuuri.conf


### PR DESCRIPTION
No other commands uses `sudo` except the two.

Remove `sudo` from command line examples for better consistency.