### PR TITLE
Remove redundant list() call

### DIFF
--- a/src/foomuuri
+++ b/src/foomuuri
@@ -166,7 +166,7 @@ class TypedConfig:
     def __iter__(self):
         """Return attributes list terator."""
         # pylint: disable=no-member
-        return iter(list(self.__dataclass_fields__))
+        return iter(self.__dataclass_fields__)
 
     def _check_set_append_args(self, name: str, value: str) -> None:
         """Verify attribute name and value sanity."""


### PR DESCRIPTION
Iterating over dict already returns list of dict keys.