### PR TITLE
README: Improve interface list comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Example configuration file to filter incoming traffic only:
 ```
 zone {
   localhost
-  public  eth1  # Interface list can be empty if using NetworkManager
+  public  eth1  # Interface list may be empty if using NetworkManager; glob patterns like * or e* are supported too
 }
 
 public-localhost {  # Allow specified incoming traffic


### PR DESCRIPTION
Extend comment to note users about useful ("fallback-safe") glob patters, as alternative to typing interfaces manually.