### PR TITLE
Add inline config section support

### DIFF
--- a/src/foomuuri
+++ b/src/foomuuri
@@ -793,7 +793,68 @@ def find_config_files(basedir, mask):
     return [item for item in files if not item.name.startswith(('.', '#'))]
 
 
-def read_config(require_etc_config: bool):
+def _validate_section_format(
+    current_section_id: typing.Optional[str],
+    tokens: list[str],
+    fileline: str,
+) -> str:
+    """Config file section validation helper.
+
+    Used by read_config() internally.
+    """
+    if current_section_id:
+        fail(
+            f'{fileline}New "{" ".join(tokens)}" while section '
+            f'"{current_section_id}" is still open'
+        )
+
+    if tokens.count('{') > 1:
+        fail(f'{fileline}One opening brace allowed: {" ".join(tokens)}')
+
+    if tokens.count('}') == 0:
+        if tokens[-1] != '{':
+            fail(f'{fileline}Closing brace missing: {" ".join(tokens)}')
+    elif tokens.count('}') == 1:
+        if tokens[-1] != '}':
+            fail(f'{fileline}Closing brace must be last: {" ".join(tokens)}')
+    else:
+        fail(f'{fileline}One closing brace allowed: {" ".join(tokens)}')
+
+    section_name = tokens[0]
+    section_params = tokens[1 : tokens.index('{')]
+    section_id = ' '.join([section_name] + section_params)
+
+    if section_name.startswith('_'):  # _name is protected
+        fail(f'{fileline}Unknown section: {section_id}')
+
+    if section_name in {
+        'template',
+        'target',
+        'group',
+    }:
+        if len(section_params) != 1:
+            fail(
+                f'{fileline}Section "{section_name}" must have single '
+                f'word name: {" ".join(tokens)}'
+            )
+    elif section_params and section_name not in {
+        'snat',
+        'dnat',
+        'prerouting',
+        'postrouting',
+        'forward',
+        'input',
+        'output',
+    }:
+        fail(
+            f'{fileline}Section "{section_name}" does not take '
+            f'parameters: {" ".join(tokens)}'
+        )
+
+    return section_id
+
+
+def read_config(require_etc_config: bool) -> dict:
     """Read all config files to config dict: section -> lines[].
 
     Files are read in alphabetical order, ignoring backup and hidden files.
@@ -824,8 +885,8 @@ def read_config(require_etc_config: bool):
 
     # Read all config files
     config = {}  # Final config dict
-    section = None  # Currently open section name
-    section_line = {}  # Section_name -> filename_line for error messages
+    section_line = {}  # section_id -> filename_line for error messages
+    section_id = None  # Current section id (name + parameters)
     for filename in share_config + etc_config:
         try:
             content = filename.read_text(encoding='utf-8')
@@ -862,72 +923,44 @@ def read_config(require_etc_config: bool):
                 continue
 
             # "}" is end of section
-            if len(tokens) == 1 and tokens[0] == '}':  # End of section
-                if not section:
+            if len(tokens) == 1 and tokens[0] == '}':
+                if not section_id:
                     fail(f'{fileline}Extra "}}"')
-                section = None
-
+                section_id = None
             # Section start:
-            # - "foo {"
-            # - "template foo {" / "target foo" / "group foo"
-            # - "prerouting {"
-            # - "prerouting filter mangle - 10 {"
-            elif len(tokens) >= 2 and tokens[-1] == '{':
-                if section:
-                    fail(
-                        f'{fileline}New "{" ".join(tokens)}" while section '
-                        f'"{section}" is still open'
-                    )
-                if (
-                    tokens[0] in {'template', 'target', 'group'}
-                    and len(tokens) != 3
-                ):
-                    fail(
-                        f'{fileline}Section "{tokens[0]}" must have single '
-                        f' word name: {" ".join(tokens)}'
-                    )
-                if len(tokens) > 2 and tokens[0] not in {
-                    'template',
-                    'target',
-                    'group',
-                    'snat',
-                    'dnat',
-                    'prerouting',
-                    'postrouting',
-                    'forward',
-                    'input',
-                    'output',
-                }:
-                    fail(
-                        f'{fileline}Section "{tokens[0]}" does not take '
-                        f'parameters: {" ".join(tokens)}'
-                    )
+            # - "foo [parameters] {"
+            # Or complete inline section:
+            # - "bar [parameters] { baz }"
+            elif '{' in tokens and (open_idx := tokens.index('{')) >= 1:
+                section_id = _validate_section_format(
+                    section_id, tokens, fileline
+                )
 
-                section = ' '.join(tokens[:-1])
-                if section.startswith('_'):  # _name is protected
-                    fail(f'{fileline}Unknown section: {section}')
-                if section not in config:
-                    config[section] = []
-                    section_line[section] = fileline
+                if section_id not in config:
+                    config[section_id] = []
+                    section_line[section_id] = fileline
 
+                if tokens[-1] == '}':  # inline section
+                    if inline_content := tokens[open_idx + 1 : -1]:
+                        config[section_id].append((fileline, inline_content))  # ty: ignore
+                    section_id = None
             # "foo" which is not inside section
-            elif not section:
+            elif not section_id:
                 fail(f'{fileline}Unknown line: {" ".join(tokens)}')
-
             # "foo" inside section
             else:
-                config[section].append((fileline, tokens))  # ty: ignore
+                config[section_id].append((fileline, tokens))  # ty: ignore
 
         # End of file checks
         if continuation:
             fail(f'File {filename}: Continuation "\\" at end of file')
-        if section:
+        if section_id:
             fail(
-                f'File {filename}: Section "{section}" is missing "}}" at '
+                f'File {filename}: Section "{section_id}" is missing "}}" at '
                 f'end of file'
             )
 
-    # Include section_name -> filename_line to config for error messages
+    # Include section_id -> filename_line to config for error messages
     config['_section_line'] = section_line
     return config
 

--- a/src/tests/test_read_config.py
+++ b/src/tests/test_read_config.py
@@ -1,5 +1,6 @@
 """Basic unit tests of read_config()."""
-# pylint: disable=invalid-name,import-error
+# pylint: disable=invalid-name,import-error,too-many-public-methods
+# ruff: noqa: PLR0904 (too-many-public-methods)
 
 import contextlib
 import unittest
@@ -30,14 +31,17 @@ class TestReadConfig(unittest.TestCase):
         with self.mock_config("""
             iplist {
             }
+            foomuuri { }
         """) as config_file:
             config = read_config(require_etc_config=False)
             self.assertDictEqual(
                 config,
                 {
                     '_section_line': {
-                        'iplist': f'File {config_file} line 2: '
+                        'foomuuri': f'File {config_file} line 4: ',
+                        'iplist': f'File {config_file} line 2: ',
                     },
+                    'foomuuri': [],
                     'iplist': [],
                 },
             )
@@ -48,16 +52,24 @@ class TestReadConfig(unittest.TestCase):
             iplist {
                 url_timeout 1d
             }
+            foomuuri { priority_offset 42 }
         """) as config_file:
             config = read_config(require_etc_config=False)
             self.assertDictEqual(
                 config,
                 {
                     '_section_line': {
-                        'iplist': f'File {config_file} line 2: '
+                        'foomuuri': f'File {config_file} line 5: ',
+                        'iplist': f'File {config_file} line 2: ',
                     },
                     'iplist': [
                         (f'File {config_file} line 3: ', ['url_timeout', '1d'])
+                    ],
+                    'foomuuri': [
+                        (
+                            f'File {config_file} line 5: ',
+                            ['priority_offset', '42'],
+                        )
                     ],
                 },
             )
@@ -69,14 +81,23 @@ class TestReadConfig(unittest.TestCase):
                 url_timeout \\
                 1d
             }
+            foomuuri { priority_offset \\
+            42 }
         """) as config_file:
             config = read_config(require_etc_config=False)
             self.assertDictEqual(
                 config,
                 {
                     '_section_line': {
-                        'iplist': f'File {config_file} line 2: '
+                        'foomuuri': f'File {config_file} line 7: ',
+                        'iplist': f'File {config_file} line 2: ',
                     },
+                    'foomuuri': [
+                        (
+                            f'File {config_file} line 7: ',
+                            ['priority_offset', '42'],
+                        )
+                    ],
                     'iplist': [
                         (f'File {config_file} line 4: ', ['url_timeout', '1d'])
                     ],
@@ -108,7 +129,7 @@ class TestReadConfig(unittest.TestCase):
             iplist {
             }
             url_timeout 1d
-        \\""") as config_file,
+        """) as config_file,
             unittest.mock.patch(
                 'foomuuri.fail', side_effect=SystemExit
             ) as fail,
@@ -120,11 +141,30 @@ class TestReadConfig(unittest.TestCase):
                 f'File {config_file} line 4: Unknown line: url_timeout 1d'
             )
 
+    def test_content_outside_inline_section(self):
+        """Test content outside inline section."""
+        with (
+            self.mock_config("""
+            iplist { } url_timeout 1d
+        """) as config_file,
+            unittest.mock.patch(
+                'foomuuri.fail', side_effect=SystemExit
+            ) as fail,
+        ):
+            self.assertRaises(
+                SystemExit, read_config, require_etc_config=False
+            )
+            fail.assert_called_once_with(
+                f'File {config_file} line 2: '
+                'Closing brace must be last: iplist { } url_timeout 1d'
+            )
+
     def test_section_with_parameters(self):
         """Test section with parameters."""
         with self.mock_config("""
             prerouting filter mangle - 10 {
             }
+            template template_name { }
         """) as config_file:
             config = read_config(require_etc_config=False)
             self.assertDictEqual(
@@ -132,10 +172,32 @@ class TestReadConfig(unittest.TestCase):
                 {
                     '_section_line': {
                         'prerouting filter mangle - 10': f'File {config_file} '
-                        'line 2: '
+                        'line 2: ',
+                        'template template_name': f'File {config_file} '
+                        'line 4: ',
                     },
                     'prerouting filter mangle - 10': [],
+                    'template template_name': [],
                 },
+            )
+
+    def test_section_with_single_word_parameter(self):
+        """Test section accepting single word parameter only."""
+        with (
+            self.mock_config("""
+            template param1 param2 {
+            }
+        """) as config_file,
+            unittest.mock.patch(
+                'foomuuri.fail', side_effect=SystemExit
+            ) as fail,
+        ):
+            self.assertRaises(
+                SystemExit, read_config, require_etc_config=False
+            )
+            fail.assert_called_once_with(
+                f'File {config_file} line 2: Section "template" '
+                'must have single word name: template param1 param2 {'
             )
 
     def test_parameter_for_parameterless_section(self):
@@ -176,6 +238,24 @@ class TestReadConfig(unittest.TestCase):
                 '"}" at end of file'
             )
 
+    def test_inline_section_missing_closing_brace(self):
+        """Test inline_section without closing brace."""
+        with (
+            self.mock_config("""
+            iplist { url_timeout 1d
+        """) as config_file,
+            unittest.mock.patch(
+                'foomuuri.fail', side_effect=SystemExit
+            ) as fail,
+        ):
+            self.assertRaises(
+                SystemExit, read_config, require_etc_config=False
+            )
+            fail.assert_called_once_with(
+                f'File {config_file} line 2: '
+                'Closing brace missing: iplist { url_timeout 1d'
+            )
+
     def test_stray_closing_brace(self):
         """Test stray closing brace."""
         with (
@@ -193,6 +273,42 @@ class TestReadConfig(unittest.TestCase):
             )
             fail.assert_called_once_with(
                 f'File {config_file} line 4: Extra "}}"'
+            )
+
+    def test_inline_section_extra_closing_brace(self):
+        """Test inline section with extra closing brace."""
+        with (
+            self.mock_config("""
+            foomuuri { bar } }
+        """) as config_file,
+            unittest.mock.patch(
+                'foomuuri.fail', side_effect=SystemExit
+            ) as fail,
+        ):
+            self.assertRaises(
+                SystemExit, read_config, require_etc_config=False
+            )
+            fail.assert_called_once_with(
+                f'File {config_file} line 2: '
+                'One closing brace allowed: foomuuri { bar } }'
+            )
+
+    def test_inline_section_extra_opening_braces(self):
+        """Test extra opening braces for inline section."""
+        with (
+            self.mock_config("""
+            foomuuri { bar } iplist {
+        """) as config_file,
+            unittest.mock.patch(
+                'foomuuri.fail', side_effect=SystemExit
+            ) as fail,
+        ):
+            self.assertRaises(
+                SystemExit, read_config, require_etc_config=False
+            )
+            fail.assert_called_once_with(
+                f'File {config_file} line 2: '
+                'One opening brace allowed: foomuuri { bar } iplist {'
             )
 
     def test_section_nesting(self):
@@ -243,14 +359,23 @@ class TestReadConfig(unittest.TestCase):
                 # comment inside section
                 url_timeout 1d      # comment section content
             }   # comment on section close
+
+            foomuuri { priority_offset 42 }    # comment inline section
         """) as config_file:
             config = read_config(require_etc_config=False)
             self.assertDictEqual(
                 config,
                 {
                     '_section_line': {
-                        'iplist': f'File {config_file} line 3: '
+                        'foomuuri': f'File {config_file} line 8: ',
+                        'iplist': f'File {config_file} line 3: ',
                     },
+                    'foomuuri': [
+                        (
+                            f'File {config_file} line 8: ',
+                            ['priority_offset', '42'],
+                        )
+                    ],
                     'iplist': [
                         (f'File {config_file} line 5: ', ['url_timeout', '1d'])
                     ],


### PR DESCRIPTION
Adds support for `foo [parameter] { bar }` (inline section definition in configuration file).

However, the new feature turned into a small refactor, including:

- Minor readability improvements.
- Splitting section validation into a separate helper function, since `read_config()` was getting too big. As a result, the helper function and the main loop of `read_config()` fit on one screen and are easier to follow.

Addresses request from https://github.com/FoobarOy/foomuuri/discussions/200