### PR TITLE
Refactor read_config() wordchars and tokenizer args

### DIFF
--- a/src/foomuuri
+++ b/src/foomuuri
@@ -875,12 +875,11 @@ def read_config(require_etc_config: bool) -> dict:
             'configuration.'
         )
 
-    # There characters will combine to single word in shlex
+    # These characters form a single word in shlex
     wordchars = ''.join(
-        chr(letter)
-        for letter in range(33, 256)
-        # excludes: " # ' ; { }
-        if letter not in {34, 35, 39, 59, 123, 125}
+        char
+        for code in range(33, 256)
+        if (char := chr(code)) not in {'"', "'", ';', '{', '}'}
     )
 
     # Read all config files
@@ -914,7 +913,7 @@ def read_config(require_etc_config: bool) -> dict:
             # used to avoid macro expansion.
             fileline = f'File {filename} line {linenumber + 1}: '
             try:
-                lexer = shlex.shlex(line, punctuation_chars=';{')
+                lexer = shlex.shlex(line)
                 lexer.wordchars = wordchars
                 tokens = list(lexer)
             except ValueError as error:

--- a/src/tests/test_read_config.py
+++ b/src/tests/test_read_config.py
@@ -432,3 +432,65 @@ class TestReadConfig(unittest.TestCase):
                     ],
                 },
             )
+
+    def test_tokenizer_delimiters_and_glued_comments(self):
+        """Test all supported tokenizer delimiters and glued comments."""
+        with self.mock_config("""
+            macro{#comment
+                macro1 http;https;;smtp#comment
+                macro2 ftp log "message ; 1"#comment
+                macro3 ntp log 'message { 2 }'#comment
+            }#comment
+            foomuuri{priority_offset 42}#comment
+        """) as config_file:
+            config = read_config(require_etc_config=False)
+            self.assertDictEqual(
+                config,
+                {
+                    '_section_line': {
+                        'macro': f'File {config_file} line 2: ',
+                        'foomuuri': f'File {config_file} line 7: ',
+                    },
+                    'macro': [
+                        (
+                            f'File {config_file} line 3: ',
+                            ['macro1', 'http', ';', 'https', ';', ';', 'smtp'],
+                        ),
+                        (
+                            f'File {config_file} line 4: ',
+                            ['macro2', 'ftp', 'log', '"message ; 1"'],
+                        ),
+                        (
+                            f'File {config_file} line 5: ',
+                            ['macro3', 'ntp', 'log', "'message { 2 }'"],
+                        ),
+                    ],
+                    'foomuuri': [
+                        (
+                            f'File {config_file} line 7: ',
+                            ['priority_offset', '42'],
+                        )
+                    ],
+                },
+            )
+
+    def test_tokenizer_unbalanced_quotes_fail(self):
+        """Test tokenizer failure on unbalanced quotes."""
+        for style, config in [
+            ('double', 'section { "content }'),
+            ('single', "section { 'content }"),
+        ]:
+            with (
+                self.subTest(quote_style=style),
+                self.mock_config(config) as config_file,
+                unittest.mock.patch(
+                    'foomuuri.fail', side_effect=SystemExit
+                ) as fail,
+            ):
+                self.assertRaises(
+                    SystemExit, read_config, require_etc_config=False
+                )
+                fail.assert_called_once_with(
+                    f"File {config_file} line 1: Can't parse line: "
+                    'No closing quotation'
+                )


### PR DESCRIPTION
Define `wordchars` using excluded characters instead of their ASCII codes for readability.

Remove `#` from wordchar exclusions as `#` is `shlex.shlex()` default commenter value.

Reword `wordchar` definition comment.

Remove `punctuation_chars=';{'` argument from `shlex.shlex()` as there is no need to parse sequences of `;` or '{` as single tokens.

Add unit tests to:
1. Verify all supported tokenizer delimiters and non-whitespaced comments.
2. Verify unbalanced quotes failure.