### PR TITLE
Improve print_table() efficiency

### DIFF
--- a/src/foomuuri
+++ b/src/foomuuri
@@ -550,7 +550,7 @@ def print_table(
     if not data or (header and len(data) == 1):
         return
 
-    if not set(align).issubset(set('^<>')):
+    if not set(align).issubset('^<>'):
         raise ValueError('Supported alignment: left <, right >, center ^')
 
     columns = len(data[0])
@@ -566,15 +566,15 @@ def print_table(
     for r, row in enumerate(data):
         print(
             sep.join(
-                f'{column:{align[c]}{width[c]}}'
-                for c, column in enumerate(row)
+                [
+                    f'{column:{align[c]}{width[c]}}'
+                    for c, column in enumerate(row)
+                ]
             ).rstrip(),
         )
 
         if header and not r:
-            print(
-                sep.join([f'{"-" * width[c]}' for c in range(columns)]),
-            )
+            print(sep.join(['-' * w for w in width]))
 
 
 def out(line: str) -> None:


### PR DESCRIPTION
Turns out, `str.join()` is measurably faster with a list comprehension than a generator. `join()` renders a generator into a list internally, and does it less efficiently than a comprehension. So there are no memory savings for generator to balance its speed loss.

There is no need to construct `set()` in the `issubset()` arg, as `issubset()` supports strings, and set object construction is slower than searching a short string.

Those improvements are on the ns scale, so virtually no noticeable difference, but a free win is a win.