### PR TITLE
Improve TypedConfig type hints and field lookups

### DIFF
--- a/src/foomuuri
+++ b/src/foomuuri
@@ -138,11 +138,10 @@ class Converters:  # pylint: disable=too-few-public-methods
 class TypedConfig:
     """Storage class with simple attribute type enforcement and validation."""
 
-    def __setattr__(self, name, value):
-        """Set attribute value."""
-        if (field := self._get_field(name)) is None:
-            raise AttributeError(f'{name}: unknown attribute')
-        expected_type = field.type
+    def __setattr__(self, name: str, value: object) -> None:
+        """Validate and set attribute value."""
+        field = self._get_field(name)
+        expected_type: typing.Any = field.type
         # Work around Python 3.9's handling of Union type hints.
         if typing.get_origin(expected_type) is typing.Union:
             expected_type = typing.get_args(expected_type)
@@ -155,36 +154,44 @@ class TypedConfig:
             raise ValueError(f'{name}: value failed validation')
         super().__setattr__(name, value)
 
-    def get(self, name, default=None):
+    def get(self, name: str, default: typing.Any = None) -> typing.Any:
         """Get attribute value."""
         return getattr(self, name, default)
 
-    def __getitem__(self, name):
+    def __getitem__(self, name: str) -> typing.Any:
         """Get attribute value via index operator."""
         return getattr(self, name)
 
-    def __setitem__(self, name, value):
-        """Set attribute value."""
+    def __setitem__(self, name: str, value: object) -> None:
+        """Set attribute value via index operator."""
         self.__setattr__(name, value)
 
-    def __iter__(self):
-        """Return attributes list terator."""
+    def __iter__(self) -> typing.Iterator[str]:
+        """Iterate over dataclass field names."""
         # pylint: disable=no-member
         return iter(self.__dataclass_fields__)
 
-    def _check_set_append_args(self, name: str, value: str) -> None:
-        """Verify attribute name and value sanity."""
-        if name not in self:
-            raise AttributeError(f'{name}: unknown attribute')
+    def __contains__(self, name: str) -> bool:
+        """Check dataclass field name membership."""
+        # pylint: disable=no-member
+        return name in self.__dataclass_fields__
+
+    def _check_set_append_args(
+        self, name: str, value: str
+    ) -> dataclasses.Field:
+        """Return field after validating name and value."""
+        field = self._get_field(name)
         if not isinstance(value, str):
             raise TypeError(
                 f'{name}: expected value type {str}, got {type(value)}'
             )
+        return field
 
-    def _convert_set_append_value(self, name: str, value: str):
-        """Convert value to attribute's type."""
-        field = self._get_field(name)
-
+    @staticmethod
+    def _convert_set_append_value(
+        field: dataclasses.Field, value: str
+    ) -> typing.Any:
+        """Convert string using field type and metadata."""
         # "Built-in" value converters. Executed when
         # convert_str is not defined in field metadata.
         implicit_converters = {
@@ -199,24 +206,23 @@ class TypedConfig:
             or implicit_converters.get(field.type)
         ):
             return converter(value)
-        if isinstance(value, field.type):
+        field_type: typing.Any = field.type
+        if isinstance(value, field_type):
             return value
         raise TypeError(
-            f'{name}: value conversion to {field.type} not implemented'
+            f'{field.name}: value conversion to {field.type} not implemented'
         )
 
-    def set_from_str(self, name, value: str) -> None:
-        """Set attribute value from str with type conversion."""
-        self._check_set_append_args(name, value)
-        new_value = self._convert_set_append_value(name, value)
+    def set_from_str(self, name: str, value: str) -> None:
+        """Set attribute value converted from string."""
+        field = self._check_set_append_args(name, value)
+        new_value = self._convert_set_append_value(field, value)
         setattr(self, name, new_value)
 
-    def append_from_str(self, name, value: str) -> None:
-        """Append attribute value from str with type conversion."""
-        self._check_set_append_args(name, value)
-        new_value = self._convert_set_append_value(name, value)
-
-        field = self._get_field(name)
+    def append_from_str(self, name: str, value: str) -> None:
+        """Append attribute value converted from string."""
+        field = self._check_set_append_args(name, value)
+        new_value = self._convert_set_append_value(field, value)
 
         # "Built-in" implicit appenders.
         implicit_appenders = {
@@ -225,8 +231,9 @@ class TypedConfig:
             list: lambda value, append: value + append,
         }
 
+        field_type: typing.Any = field.type
         if (appender := implicit_appenders.get(field.type)) and isinstance(
-            new_value, field.type
+            new_value, field_type
         ):
             new_value = appender(self[name], new_value)
         else:
@@ -236,10 +243,12 @@ class TypedConfig:
 
         setattr(self, name, new_value)
 
-    def _get_field(self, name, default=None):
-        """Get dataclass field by attribute name."""
+    def _get_field(self, name: str) -> dataclasses.Field:
+        """Get dataclass field for attribute name."""
         # pylint: disable=no-member
-        return self.__dataclass_fields__.get(name, default)
+        if (field := self.__dataclass_fields__.get(name)) is None:
+            raise AttributeError(f'{name}: unknown attribute')
+        return field
 
 
 @dataclasses.dataclass

--- a/src/tests/test_typed_config.py
+++ b/src/tests/test_typed_config.py
@@ -54,7 +54,7 @@ class TestTypedConfig(unittest.TestCase):
         self.config = TestConfig()
 
     def test_accessor_style(self):
-        """Test dict/dot style accessor/setter."""
+        """Test index and dot access and assignment."""
         self.config.initialized_str = 'new_value1'
         self.assertEqual(self.config.initialized_str, 'new_value1')
         self.assertRaises(
@@ -70,12 +70,12 @@ class TestTypedConfig(unittest.TestCase):
         self.assertRaises(AttributeError, self.set, 'unknown_attribute', '123')
 
     def test_initialized_typed(self):
-        """Test assigning values to initialized typed attributes."""
+        """Test assignment to initialized typed attributes."""
         self.assertRaises(TypeError, self.set, 'initialized_str', 123)
         self.assertEqual(self.set('initialized_str', 'value'), 'value')
 
     def test_uninitialized_typed(self):
-        """Test assigning values to uninialized typed attributes."""
+        """Test assignment to uninitialized typed attributes."""
         self.assertRaises(
             AttributeError, lambda: self.config.uninitialized_str
         )
@@ -83,13 +83,18 @@ class TestTypedConfig(unittest.TestCase):
         self.assertEqual(self.set('uninitialized_str', 'value'), 'value')
 
     def test_initialized_untyped(self):
-        """Test accessing listed untyped attributes."""
-        self.assertRaises(
-            AttributeError, lambda: self.config.uninitialized_untyped
-        )
+        """Test access to initialized untyped attribute.
+
+        Untyped attributes can be read, but cannot be written to.
+        Gating attribute reads via dataclass fields membership is expensive and
+        is not needed anyway.
+        """
+        self.assertEqual(self.config.initialized_untyped, 'init_value2')
+        with self.assertRaises(AttributeError):
+            self.config.initialized_untyped = 'new_value'
 
     def test_union_type(self):
-        """Test assigning values to Union attributes."""
+        """Test assignment to Union attributes."""
         self.config.union_str_or_none = 'value'
         self.assertEqual(self.config.union_str_or_none, 'value')
         self.config.union_str_or_none = None
@@ -98,7 +103,7 @@ class TestTypedConfig(unittest.TestCase):
             self.config.union_str_or_none = 1  # ty: ignore[invalid-assignment]
 
     def test_set_from_str(self):
-        """Test attribute type conversion from str (set_from_str)."""
+        """Test attribute type conversion from strings."""
         # Invalid value type: only str supported
         self.assertRaises(
             TypeError, self.config.set_from_str, 'type_conversion_int', 123
@@ -137,7 +142,7 @@ class TestTypedConfig(unittest.TestCase):
         )
 
     def test_append_from_str(self):
-        """Test attribute value append from str (append_from_str)."""
+        """Test attribute type conversion and appending from strings."""
         # Invalid value type: only str supported
         self.assertRaises(
             TypeError, self.config.append_from_str, 'initialized_str', 123
@@ -176,12 +181,12 @@ class TestTypedConfig(unittest.TestCase):
         )
 
     def test_validation(self):
-        """Test attribute validation helper call."""
+        """Test attribute metadata validation."""
         self.assertRaises(ValueError, self.set, 'validation', '')
         self.assertEqual(self.set('validation', 'test'), 'test')
 
     def test_iter(self):
-        """Test __iter__."""
+        """Test dataclass field names iteration."""
         self.assertEqual(
             sorted(self.config),
             [
@@ -198,7 +203,12 @@ class TestTypedConfig(unittest.TestCase):
             ],
         )
 
+    def test_contains(self):
+        """Test dataclass field name membership."""
+        self.assertIn('initialized_str', self.config)
+        self.assertNotIn('unknown_attribute', self.config)
+
     def test_get(self):
-        """Test get."""
+        """Test get() attribute lookup."""
         self.assertEqual(self.config.get('initialized_str'), 'init_value1')
-        self.assertEqual(self.config.get('unknown_attr'), None)
+        self.assertEqual(self.config.get('unknown_attribute'), None)


### PR DESCRIPTION
Add missing type annotations.

Add `__contains__` method for O(1) membership lookups (`in`).

Reuse resolved field returned by `_get_field()` for value conversion and appending.

Remove unused `default` parameter of `_get_field()`.

Reword docstrings.