### PR TITLE
Move CONFIG_OVERRIDE, HELPERS, LOGRATES to INTERNAL

### DIFF
--- a/src/foomuuri
+++ b/src/foomuuri
@@ -1626,6 +1626,8 @@ def verify_rule_sanity(rule: Rule, fileline: str) -> None:
     for basic, extra in (
         ('protocol', 'sport'),
         ('protocol', 'dport'),
+        ('protocol', 'helper'),
+        ('dport', 'helper'),
         ('saddr_rate', 'saddr_rate_name'),
         ('saddr_rate', 'saddr_rate_mask'),
         ('daddr_rate', 'daddr_rate_name'),

--- a/src/foomuuri
+++ b/src/foomuuri
@@ -278,12 +278,12 @@ class Config(TypedConfig):
     dbus_zone: str = dataclasses.field(
         default='public', metadata={'validate': Validators.str_zone_name}
     )
-    rpfilter: set = dataclasses.field(
+    rpfilter: set[str] = dataclasses.field(
         default_factory=lambda: {'yes'},
         metadata={'validate': Validators.has_elements},
     )
-    flowtable: set = dataclasses.field(default_factory=set)
-    counter: set = dataclasses.field(
+    flowtable: set[str] = dataclasses.field(default_factory=set)
+    counter: set[str] = dataclasses.field(
         default_factory=lambda: {'no'},
         metadata={'validate': Validators.has_elements},
     )
@@ -297,7 +297,7 @@ class Config(TypedConfig):
     dbus_firewalld: str = dataclasses.field(
         default='no', metadata={'validate': Validators.str_yes_no}
     )
-    nft_bin: list = dataclasses.field(
+    nft_bin: list[str] = dataclasses.field(
         default_factory=lambda: ['nft'],
         metadata={
             'convert_str': shlex.split,
@@ -362,24 +362,26 @@ class Internal(TypedConfig):
         default_factory=list
     )
     # Added without default value to prevent uninitialized use
-    iplist_missing_ok: set = dataclasses.field(init=False)
+    iplist_missing_ok: set[str] = dataclasses.field(init=False)
     keep_going: int = dataclasses.field(init=False)
-    post_start: list = dataclasses.field(init=False)
-    post_stop: list = dataclasses.field(init=False)
-    pre_start: list = dataclasses.field(init=False)
-    pre_stop: list = dataclasses.field(init=False)
+    post_start: list[str] = dataclasses.field(init=False)
+    post_stop: list[str] = dataclasses.field(init=False)
+    pre_start: list[str] = dataclasses.field(init=False)
+    pre_stop: list[str] = dataclasses.field(init=False)
     priority_offset: str = dataclasses.field(init=False)
     catch_all_interface_zone: str = dataclasses.field(init=False)
     root_power: bool = dataclasses.field(init=False)  # Running as "root"?
-    zonemap_loop_check: dict = dataclasses.field(init=False)
+    zonemap_loop_check: dict[tuple[str, str, str, str], 'Rule'] = (
+        dataclasses.field(init=False)
+    )  # (szone, dzone, new_szone, new_dzone) -> Rule
 
     # Url loader
     # Constants
     url_chunk_size: int = 1_048_576
-    url_get_timeout: dict = dataclasses.field(
+    url_get_timeout: dict[str, float] = dataclasses.field(
         default_factory=lambda: {'connect': 3.05, 'read': 3.05}
     )  # Timeouts (seconds)
-    url_get_retries: dict = dataclasses.field(
+    url_get_retries: dict[str, typing.Union[int, bool]] = dataclasses.field(
         default_factory=lambda: {
             'connect': 3,
             'redirect': 3,
@@ -597,8 +599,8 @@ class Rule(TypedConfig):  # pylint: disable=too-many-instance-attributes
     # Internal housekeeping
     plain: bool = True  # Plain "log" or "counter" without anything else
     fileline: str = dataclasses.field(default='')  # For error messages
-    line: list = dataclasses.field(default_factory=list)  # Original line
-    only_one: dict = dataclasses.field(default_factory=dict)
+    line: list[str] = dataclasses.field(default_factory=list)  # Original line
+    only_one: dict[str, str] = dataclasses.field(default_factory=dict)
 
 
 RuleList = list[Rule]

--- a/src/foomuuri
+++ b/src/foomuuri
@@ -141,10 +141,7 @@ class TypedConfig:
     def __setattr__(self, name: str, value: object) -> None:
         """Validate and set attribute value."""
         field = self._get_field(name)
-        expected_type: typing.Any = field.type
-        # Work around Python 3.9's handling of Union type hints.
-        if typing.get_origin(expected_type) is typing.Union:
-            expected_type = typing.get_args(expected_type)
+        expected_type = self._isinstance_target(field.type)
         if not isinstance(value, expected_type):
             raise TypeError(
                 f'{name}: expected value type {field.type}, got {type(value)}'
@@ -153,6 +150,21 @@ class TypedConfig:
         if validator and not validator(value):
             raise ValueError(f'{name}: value failed validation')
         super().__setattr__(name, value)
+
+    @staticmethod
+    def _isinstance_target(expected_type):
+        """Return isinstance() target of a type hint.
+
+        Convert parameterized hints to their origin and typing.Union
+        hints to tuples of targets.
+        """
+        type_origin = typing.get_origin(expected_type)
+        if type_origin is typing.Union:
+            return tuple(
+                TypedConfig._isinstance_target(arg)
+                for arg in typing.get_args(expected_type)
+            )
+        return type_origin or expected_type
 
     def get(self, name: str, default: typing.Any = None) -> typing.Any:
         """Get attribute value."""
@@ -176,22 +188,16 @@ class TypedConfig:
         # pylint: disable=no-member
         return name in self.__dataclass_fields__
 
-    def _check_set_append_args(
-        self, name: str, value: str
-    ) -> dataclasses.Field:
-        """Return field after validating name and value."""
-        field = self._get_field(name)
-        if not isinstance(value, str):
-            raise TypeError(
-                f'{name}: expected value type {str}, got {type(value)}'
-            )
-        return field
-
-    @staticmethod
-    def _convert_set_append_value(
-        field: dataclasses.Field, value: str
+    def _convert_from_str(
+        self, field: dataclasses.Field, value: str
     ) -> typing.Any:
         """Convert string using field type and metadata."""
+        if not isinstance(value, str):
+            raise TypeError(
+                f'{field.name}: expected value type {str}, got {type(value)}'
+            )
+        expected_type = self._isinstance_target(field.type)
+
         # "Built-in" value converters. Executed when
         # convert_str is not defined in field metadata.
         implicit_converters = {
@@ -203,11 +209,10 @@ class TypedConfig:
 
         if converter := (
             field.metadata.get('convert_str')
-            or implicit_converters.get(field.type)
+            or implicit_converters.get(expected_type)
         ):
             return converter(value)
-        field_type: typing.Any = field.type
-        if isinstance(value, field_type):
+        if isinstance(value, expected_type):
             return value
         raise TypeError(
             f'{field.name}: value conversion to {field.type} not implemented'
@@ -215,14 +220,15 @@ class TypedConfig:
 
     def set_from_str(self, name: str, value: str) -> None:
         """Set attribute value converted from string."""
-        field = self._check_set_append_args(name, value)
-        new_value = self._convert_set_append_value(field, value)
+        field = self._get_field(name)
+        new_value = self._convert_from_str(field, value)
         setattr(self, name, new_value)
 
     def append_from_str(self, name: str, value: str) -> None:
         """Append attribute value converted from string."""
-        field = self._check_set_append_args(name, value)
-        new_value = self._convert_set_append_value(field, value)
+        field = self._get_field(name)
+        new_value = self._convert_from_str(field, value)
+        expected_type = self._isinstance_target(field.type)
 
         # "Built-in" implicit appenders.
         implicit_appenders = {
@@ -231,9 +237,8 @@ class TypedConfig:
             list: lambda value, append: value + append,
         }
 
-        field_type: typing.Any = field.type
-        if (appender := implicit_appenders.get(field.type)) and isinstance(
-            new_value, field_type
+        if (appender := implicit_appenders.get(expected_type)) and isinstance(
+            new_value, expected_type
         ):
             new_value = appender(self[name], new_value)
         else:

--- a/src/foomuuri
+++ b/src/foomuuri
@@ -348,8 +348,19 @@ class Internal(TypedConfig):
         default_factory=list
     )  # Parameters for command
     force: int = 0  # --force
+    config_override: dict[str, typing.Union[str, int]] = dataclasses.field(
+        default_factory=dict
+    )
 
     # Other internally used variables
+    # Lograte names and limits: name -> (log statement, rule statement)
+    logrates: dict[str, tuple[str, str]] = dataclasses.field(
+        default_factory=dict
+    )
+    # List of helpers: (helper, protocol, ports)
+    helpers: list[tuple[str, str, str]] = dataclasses.field(
+        default_factory=list
+    )
     # Added without default value to prevent uninitialized use
     iplist_missing_ok: set = dataclasses.field(init=False)
     keep_going: int = dataclasses.field(init=False)
@@ -598,12 +609,9 @@ SpecialChainRules = dict[SpecialChainKey, RuleList]
 
 
 CONFIG = Config()
-CONFIG_OVERRIDE = {}
 INTERNAL = Internal()
 
 OUT = []  # Generated nftables ruleset / commands
-LOGRATES = {}  # Lograte names and limits
-HELPERS = []  # List of helpers: (helper-object, protocol, ports)
 
 
 def fail(error: str, fatal: bool = True) -> int:
@@ -1320,7 +1328,7 @@ def parse_config_foomuuri(config):
             )
 
     # Overrides from CLI arguments
-    for name, value in CONFIG_OVERRIDE.items():
+    for name, value in INTERNAL.config_override.items():
         CONFIG.set_from_str(name, str(value))
 
     # Reinitialize syslogging, foomuuri{} may have a different syslog setting
@@ -2353,8 +2361,8 @@ def rule_statement(
             )
             if statement == 'continue':
                 return f'{prefix}{rate}{log_nft}'
-            logname = f'lograte_{len(LOGRATES) + 1}'
-            LOGRATES[logname] = (f'{rate}{log_nft}', statement)
+            logname = f'lograte_{len(INTERNAL.logrates) + 1}'
+            INTERNAL.logrates[logname] = (f'{rate}{log_nft}', statement)
             return f'{prefix}jump {logname}'
         prefix += f'{log_nft} '
 
@@ -2759,7 +2767,13 @@ def output_cast(
         if rule.helper:
             if rule.helper.count('-') != 1:
                 fail(f'{rule.fileline}Invalid helper name: {rule.helper}')
-            HELPERS.append((rule.helper, rule.protocol, rule.dport))
+            INTERNAL.helpers.append(
+                (
+                    rule.helper,
+                    typing.cast('str', rule.protocol),
+                    typing.cast('str', rule.dport),
+                )
+            )
             kernelname = rule.helper.split('-')[0].replace('_', '-')
             out(f'ct helper "{kernelname}" {rule.statement}')
     return has_needle_rule
@@ -3271,7 +3285,7 @@ def optimize_jumps():
         line = OUT[linenum]
         if line.startswith('jump lograte_'):
             logname = line.split()[1]
-            log_nft, statement = LOGRATES.pop(logname)
+            log_nft, statement = INTERNAL.logrates.pop(logname)
             OUT[linenum] = log_nft
             OUT.insert(linenum + 1, statement)
         linenum += 1
@@ -3289,7 +3303,7 @@ def optimize_final_rules():
 
 def output_logrates():
     """Output non-optimized lograte entries as chains."""
-    for logname, (log_nft, statement) in LOGRATES.items():
+    for logname, (log_nft, statement) in INTERNAL.logrates.items():
         out(f'chain {logname} {{')
         out(log_nft)
         out(statement)
@@ -3346,7 +3360,7 @@ def output_helpers():
     """Output helpers."""
     # Convert helper list to helper->proto->set(ports) dict
     helpers = {}
-    for name, proto, ports in HELPERS:
+    for name, proto, ports in INTERNAL.helpers:
         if name not in helpers:
             helpers[name] = {}
         if proto not in helpers[name]:
@@ -5967,14 +5981,18 @@ def parse_command_line():
         elif arg == '--verbose':
             option = arg[2:]
             CONFIG[option] += 1
-            CONFIG_OVERRIDE[option] = CONFIG_OVERRIDE.get(option, 0) + 1
+            INTERNAL.config_override[option] = (
+                int(INTERNAL.config_override.get(option, 0)) + 1
+            )
         elif arg == '--quiet':
             option = 'verbose'
             CONFIG[option] -= 1
-            CONFIG_OVERRIDE[option] = CONFIG_OVERRIDE.get(option, 0) - 1
+            INTERNAL.config_override[option] = (
+                int(INTERNAL.config_override.get(option, 0)) - 1
+            )
         elif arg in {'--fork', '--syslog'}:
             CONFIG[arg[2:]] = 1
-            CONFIG_OVERRIDE[arg[2:]] = 1
+            INTERNAL.config_override[arg[2:]] = 1
         elif arg == '--force':
             INTERNAL.force += 1
         elif arg == '--soft':
@@ -5987,7 +6005,7 @@ def parse_command_line():
                 fail(f'Unknown foomuuri{{}} option: {option}')
             try:
                 CONFIG.set_from_str(option, value)
-                CONFIG_OVERRIDE[option] = value
+                INTERNAL.config_override[option] = value
             except ValueError:
                 fail(f'Invalid foomuuri{{}} option {option} value: {value}')
         elif arg.startswith('--'):

--- a/src/tests/test_parse_command_line.py
+++ b/src/tests/test_parse_command_line.py
@@ -11,7 +11,6 @@ from foomuuri import INTERNAL as BASE_INTERNAL
 from foomuuri import parse_command_line
 
 
-@unittest.mock.patch('foomuuri.CONFIG_OVERRIDE', new_callable=dict)
 @unittest.mock.patch(
     'foomuuri.CONFIG', new_callable=lambda: copy.deepcopy(BASE_CONFIG)
 )
@@ -46,59 +45,59 @@ class TestParseCommandLine(unittest.TestCase):
         'sys.argv',
         ['foomuuri', '--verbose', 'command', 'arg1', '--force', 'arg2'],
     )
-    def test_command_and_options(self, INTERNAL, CONFIG, CONFIG_OVERRIDE):
+    def test_command_and_options(self, INTERNAL, CONFIG):
         """Test command with arguments, mixed with options."""
         parse_command_line()
         self.assertEqual(INTERNAL.command, 'command')
         self.assertEqual(INTERNAL.parameters, ['arg1', 'arg2'])
         self.assertEqual(INTERNAL.force, 1)
         self.assertEqual(CONFIG.verbose, 1)
-        self.assertEqual(CONFIG_OVERRIDE['verbose'], 1)
+        self.assertEqual(INTERNAL.config_override['verbose'], 1)
 
     @unittest.mock.patch('sys.argv', ['foomuuri', '--syslog', '--fork'])
-    def test_options_syslog_fork(self, INTERNAL, CONFIG, CONFIG_OVERRIDE):
+    def test_options_syslog_fork(self, INTERNAL, CONFIG):
         """Test --syslog and --fork options."""
         parse_command_line()
         self.assertEqual(CONFIG.syslog, 1)
         self.assertEqual(CONFIG.fork, 1)
-        self.assertEqual(CONFIG_OVERRIDE['syslog'], 1)
-        self.assertEqual(CONFIG_OVERRIDE['fork'], 1)
+        self.assertEqual(INTERNAL.config_override['syslog'], 1)
+        self.assertEqual(INTERNAL.config_override['fork'], 1)
         self.assertEqual(INTERNAL.command, '')
         self.assertEqual(INTERNAL.parameters, [])
 
     @unittest.mock.patch('sys.argv', ['foomuuri', '--verbose'])
-    def test_option_verbose(self, INTERNAL, CONFIG, CONFIG_OVERRIDE):
+    def test_option_verbose(self, INTERNAL, CONFIG):
         """Test --verbose option."""
         parse_command_line()
         self.assertEqual(CONFIG.verbose, 1)
-        self.assertEqual(CONFIG_OVERRIDE['verbose'], 1)
+        self.assertEqual(INTERNAL.config_override['verbose'], 1)
         self.assertEqual(INTERNAL.command, '')
         self.assertEqual(INTERNAL.parameters, [])
 
     @unittest.mock.patch('sys.argv', ['foomuuri', '--verbose', '--verbose'])
-    def test_options_verbose_verbose(self, INTERNAL, CONFIG, CONFIG_OVERRIDE):
+    def test_options_verbose_verbose(self, INTERNAL, CONFIG):
         """Test --verbose --verbose options."""
         parse_command_line()
         self.assertEqual(CONFIG.verbose, 2)
-        self.assertEqual(CONFIG_OVERRIDE['verbose'], 2)
+        self.assertEqual(INTERNAL.config_override['verbose'], 2)
         self.assertEqual(INTERNAL.command, '')
         self.assertEqual(INTERNAL.parameters, [])
 
     @unittest.mock.patch('sys.argv', ['foomuuri', '--quiet'])
-    def test_option_quiet(self, INTERNAL, CONFIG, CONFIG_OVERRIDE):
+    def test_option_quiet(self, INTERNAL, CONFIG):
         """Test --quiet option."""
         parse_command_line()
         self.assertEqual(CONFIG.verbose, -1)
-        self.assertEqual(CONFIG_OVERRIDE['verbose'], -1)
+        self.assertEqual(INTERNAL.config_override['verbose'], -1)
         self.assertEqual(INTERNAL.command, '')
         self.assertEqual(INTERNAL.parameters, [])
 
     @unittest.mock.patch('sys.argv', ['foomuuri', '--verbose', '--quiet'])
-    def test_options_verbose_quiet(self, INTERNAL, CONFIG, CONFIG_OVERRIDE):
+    def test_options_verbose_quiet(self, INTERNAL, CONFIG):
         """Test --verbose --quiet options."""
         parse_command_line()
         self.assertEqual(CONFIG.verbose, 0)
-        self.assertEqual(CONFIG_OVERRIDE['verbose'], 0)
+        self.assertEqual(INTERNAL.config_override['verbose'], 0)
         self.assertEqual(INTERNAL.command, '')
         self.assertEqual(INTERNAL.parameters, [])
 
@@ -154,7 +153,7 @@ class TestParseCommandLine(unittest.TestCase):
         'sys.argv',
         ['foomuuri', '--set=priority_offset=42', '--set=set_size=1'],
     )
-    def test_options_set_valid(self, INTERNAL, CONFIG, _):
+    def test_options_set_valid(self, INTERNAL, CONFIG):
         """Test --set options with valid foomuuri{} CONFIG option/value."""
         parse_command_line()
         self.assertEqual(CONFIG.priority_offset, 42)

--- a/src/tests/test_parse_config_foomuuri.py
+++ b/src/tests/test_parse_config_foomuuri.py
@@ -101,13 +101,12 @@ class TestParseConfigFoomuuri(unittest.TestCase):
                 ' option value: priority_offset not_an_int'
             )
 
-    @unittest.mock.patch('foomuuri.CONFIG_OVERRIDE', new_callable=dict)
-    def test_config_override(self, CONFIG_OVERRIDE, CONFIG, *_):
-        """Test overriding of CONFIG from CONFIG_OVERRRIDE."""
+    def test_config_override(self, CONFIG, INTERNAL):
+        """Test overriding of CONFIG from config_override."""
 
         def test_override(option, override, config):
             with self.mock_config_foomuuri(option, '0'):
-                CONFIG_OVERRIDE[option] = override
+                INTERNAL.config_override[option] = override
                 _ = minimal_config()
                 self.assertEqual(CONFIG[option], config)
 

--- a/src/tests/test_parse_rule_line.py
+++ b/src/tests/test_parse_rule_line.py
@@ -1,0 +1,35 @@
+"""Test parse_rule_line()."""
+# pylint: disable=import-error
+
+import unittest
+import unittest.mock
+
+from foomuuri import parse_rule_line
+
+
+class TestParseRuleLine(unittest.TestCase):
+    """Test parse_rule_line()."""
+
+    @unittest.mock.patch('foomuuri.fail', side_effect=SystemExit)
+    def test_incomplete_helper(self, fail):
+        """Reject incomplete helper rule."""
+        for line, error in (
+            (['helper', 'ftp-21'], '"helper" without "protocol" is not valid'),
+            (
+                ['tcp', 'helper', 'ftp-21'],
+                '"helper" without "dport" is not valid',
+            ),
+        ):
+            with self.subTest(line=line):
+                with self.assertRaises(SystemExit):
+                    parse_rule_line(('File line: ', line))
+                fail.assert_called_with(f'File line: {error}')
+
+    def test_valid_helper(self):
+        """Accept valid helper rule."""
+        rule = parse_rule_line(
+            ('File line: ', ['tcp', '21', 'helper', 'ftp-21'])
+        )
+        self.assertEqual(rule.protocol, 'tcp')
+        self.assertEqual(rule.dport, '21')
+        self.assertEqual(rule.helper, 'ftp-21')

--- a/src/tests/test_typed_config.py
+++ b/src/tests/test_typed_config.py
@@ -44,6 +44,11 @@ class TestTypedConfig(unittest.TestCase):
             type_conversion_list: list = field(default_factory=list)
             type_conversion_posixpath: pathlib.PosixPath = field(init=False)
             type_conversion_set: set = field(default_factory=set)
+            parametrized_list: list[str] = field(default_factory=list)
+            parametrized_dict: dict[str, int] = field(default_factory=dict)
+            parametrized_union: typing.Union[list[str], int] = field(
+                default_factory=list
+            )
             validation: str = field(
                 init=False, metadata={'validate': lambda v: v}
             )
@@ -68,6 +73,26 @@ class TestTypedConfig(unittest.TestCase):
         )
 
         self.assertRaises(AttributeError, self.set, 'unknown_attribute', '123')
+
+    def test_parameterized_types(self):
+        """Test assigning parametrized types attributes."""
+        self.assertListEqual(
+            self.set('parametrized_list', ['value']), ['value']
+        )
+        self.assertDictEqual(
+            self.set('parametrized_dict', {'key': 1}), {'key': 1}
+        )
+        with self.assertRaises(TypeError):
+            self.set('parametrized_list', {})
+        with self.assertRaises(TypeError):
+            self.set('parametrized_dict', [])
+
+    def test_parameterized_union_types(self):
+        """Test assigning to Union attributes with parametrized args."""
+        self.assertEqual(self.set('parametrized_union', ['value']), ['value'])
+        self.assertEqual(self.set('parametrized_union', 1), 1)
+        with self.assertRaises(TypeError):
+            self.set('parametrized_union', {'key': 1})
 
     def test_initialized_typed(self):
         """Test assignment to initialized typed attributes."""
@@ -125,6 +150,15 @@ class TestTypedConfig(unittest.TestCase):
             self.set_from_str('type_conversion_set', '1 2 2 3 4'),
             {'1', '2', '3', '4'},
         )
+        # Supported conversion, from str to parametrized list
+        self.assertEqual(
+            self.set_from_str('parametrized_list', '1 2'),
+            ['1', '2'],
+        )
+        # Unsupported conversion, from str to parametrized dict
+        self.assertRaises(
+            TypeError, self.config.set_from_str, 'parametrized_dict', 'key'
+        )
         # Assignment, str to str
         self.assertEqual(self.set_from_str('initialized_str', '123'), '123')
         # Assignment, list converted from str
@@ -171,6 +205,22 @@ class TestTypedConfig(unittest.TestCase):
             self.append_from_str('type_conversion_set', '2 3'),
             {'1', '2', '3'},
         )
+        # Appending, str to parametrized list
+        self.assertEqual(
+            self.set_from_str('parametrized_list', '1 2'),
+            ['1', '2'],
+        )
+        self.assertEqual(
+            self.append_from_str('parametrized_list', '2 3'),
+            ['1', '2', '2', '3'],
+        )
+        # Unsupported append, from str to parametrized dict
+        self.assertRaises(
+            TypeError,
+            self.config.append_from_str,
+            'parametrized_dict',
+            'key',
+        )
         # Unsupported append, from str to int
         self.assertRaises(
             TypeError, self.append_from_str, 'type_conversion_int', '1'
@@ -192,6 +242,9 @@ class TestTypedConfig(unittest.TestCase):
             [
                 'conversion',
                 'initialized_str',
+                'parametrized_dict',
+                'parametrized_list',
+                'parametrized_union',
                 'type_conversion_float',
                 'type_conversion_int',
                 'type_conversion_list',


### PR DESCRIPTION
Add type annotations to their attributes, while at it.

Preceding commit adds parameterized type hints support in `TypedConfig`.

Last commit adds missing helper rule validation.