### PR TITLE
Add behavioral tests around iplist update

### DIFF
--- a/src/foomuuri
+++ b/src/foomuuri
@@ -395,6 +395,11 @@ class Internal(TypedConfig):
         }
     )  # Retries count and redirect behaviour
 
+    # Iplist expire constants (in seconds)
+    # Expire values over expire_max are normalized to expire_forever
+    expire_max: int = 2 * 365 * 86400  # "Forever" borderline value
+    expire_forever: int = 4_000_000_000  # Actual "forever" value (year 2096)
+
 
 @dataclasses.dataclass
 class IPListOptions(TypedConfig):
@@ -4281,8 +4286,8 @@ def iplist_verify_filters(name, values, fileline):
 
 def normalize_expire(now: int, timeout: int) -> int:
     """Add timeout to now. If it is too large return "forever"."""
-    if timeout > 2 * 365 * 86400:  # More than 2 year
-        return 4000000000  # Year 2096 is forever
+    if timeout > Internal.expire_max:
+        return Internal.expire_forever
     return now + timeout
 
 
@@ -5036,7 +5041,7 @@ def iplist_output_values(
         for value in setvalues:
             # Static IP address doesn't need refresh, so timeout is forever
             if get_ip_family(value, allow_negative=False):
-                cache[setname]['ip'][value] = 4000000000  # forever
+                cache[setname]['ip'][value] = Internal.expire_forever
                 cache[setname]['dirty'] = True
                 continue
 

--- a/src/tests/test_iplist_get_output.py
+++ b/src/tests/test_iplist_get_output.py
@@ -1,0 +1,273 @@
+"""Test iplist get_url_or_file() and iplist_output_values().
+
+Cover iplist cache management and user interaction behaviour.
+"""
+
+# pylint: disable=invalid-name,import-error
+
+import copy
+import time
+import unittest.mock
+
+import foomuuri
+from foomuuri import INTERNAL as BASE_INTERNAL
+
+
+@unittest.mock.patch(
+    'foomuuri.INTERNAL', new_callable=lambda: copy.deepcopy(BASE_INTERNAL)
+)
+class TestIplistGetOutput(unittest.TestCase):
+    """Test get_url_or_file() and iplist_output_values() behaviour."""
+
+    def setUp(self):
+        """Prepare test fixtures."""
+        self.now = int(time.time())
+        self.url = 'https://foo.bar/iplist'
+        self.url_missing_ok = f'{self.url}|missing-ok'
+
+    @staticmethod
+    def run_get(url, cache, content, force=0):
+        """Call get_url_or_file() with mocked get_url()."""
+        foomuuri.INTERNAL.force = force
+        options = foomuuri.IPListSourceOptions()
+        options.timeout = 1000
+        options.refresh = 1000
+        with (
+            unittest.mock.patch('foomuuri.get_url', return_value=content),
+            unittest.mock.patch('foomuuri.warning') as warning,
+            unittest.mock.patch('foomuuri.verbose') as verbose,
+        ):
+            foomuuri.get_url_or_file(url, options, cache)
+        return cache.get(url), warning, verbose
+
+    @staticmethod
+    def run_output(
+        sources,
+        cache,
+        setname,
+        force=0,
+    ):
+        """Call iplist_output_values() with mocked IO."""
+        foomuuri.INTERNAL.command = 'iplist'
+        foomuuri.INTERNAL.force = force
+        iplists = foomuuri.IPLists()
+        iplists[setname] = foomuuri.IPList(sources=sources)
+        update_only = set()
+        currently_active = {setname}
+        with (
+            unittest.mock.patch('foomuuri.warning') as warning,
+            unittest.mock.patch('foomuuri.fail') as fail,
+            unittest.mock.patch('foomuuri.verbose') as verbose,
+            unittest.mock.patch('foomuuri.OUT', new=[]),
+            unittest.mock.patch(
+                'foomuuri.iplist_apply_values', return_value=0
+            ),
+        ):
+            ret = foomuuri.iplist_output_values(
+                iplists, cache, currently_active, update_only
+            )
+        return ret, warning, fail, verbose
+
+    @staticmethod
+    def source_cache(*sources, ip=None, refresh=None):
+        """Return cache dict with one entry per source."""
+        entry = {'ip': {} if ip is None else ip, 'dirty': False}
+        if refresh is not None:
+            entry['refresh'] = refresh
+        return {source: copy.deepcopy(entry) for source in sources}
+
+    def test_empty_url_missing_ok(self, *_):
+        """Test no warning for empty source with |missing-ok.
+
+        Pre-existing cache is overwritten.
+        """
+        cache = self.source_cache(
+            self.url_missing_ok, ip={'10.0.0.1': self.now}, refresh=self.now
+        )
+        entry, warning, verbose = self.run_get(
+            url=self.url_missing_ok, cache=cache, content=''
+        )
+        self.assertFalse(entry['ip'])
+        self.assertTrue(entry['dirty'])
+        warning.assert_not_called()
+        verbose.assert_called_once_with(
+            f'Iplist content for "{self.url_missing_ok}" refreshed, 0 entries'
+        )
+
+    def test_empty_url_no_missing_ok(self, *_):
+        """Test warning for empty source without |missing-ok.
+
+        Pre-existing cache is overwritten.
+        """
+        cache = self.source_cache(self.url, ip={'10.0.0.1': self.now})
+        entry, warning, verbose = self.run_get(
+            url=self.url, cache=cache, content=''
+        )
+        self.assertFalse(entry['ip'])
+        self.assertTrue(entry['dirty'])
+        warning.assert_called_once_with(
+            f'No IP addresses listed in "{self.url}"'
+        )
+        verbose.assert_called_once_with(
+            f'Iplist content for "{self.url}" refreshed, 0 entries'
+        )
+
+    def test_nonempty_url_no_missing_ok(self, *_):
+        """Test cache stores new values from source without |missing-ok."""
+        cache = self.source_cache(self.url, ip={'10.0.0.1': self.now})
+        entry, warning, verbose = self.run_get(
+            url=self.url, cache=cache, content='10.0.0.9\n'
+        )
+        self.assertIn('10.0.0.9', entry['ip'])
+        self.assertTrue(entry['dirty'])
+        warning.assert_not_called()
+        verbose.assert_called_once_with(
+            f'Iplist content for "{self.url}" refreshed, 1 entries'
+        )
+
+    def test_url_cached_soft(self, *_):
+        """Test using cache values with --soft (force<0)."""
+        cache = self.source_cache(
+            self.url, ip={'10.0.0.1': self.now}, refresh=self.now
+        )
+        entry, warning, verbose = self.run_get(
+            url=self.url, cache=cache, content='10.0.0.9\n', force=-1
+        )
+        self.assertIn('10.0.0.1', entry['ip'])
+        self.assertFalse(entry['dirty'])
+        warning.assert_not_called()
+        verbose.assert_called_once_with(f'Using cached value for "{self.url}"')
+
+    def test_url_fetch_fail(self, *_):
+        """Test cache keeping old values when fetch fails (content=None)."""
+        cache = self.source_cache(self.url, ip={'10.0.0.1': self.now})
+        entry, warning, verbose = self.run_get(
+            url=self.url, cache=cache, content=None
+        )
+        self.assertIn('10.0.0.1', entry['ip'])
+        self.assertFalse(entry['dirty'])
+        warning.assert_not_called()
+        verbose.assert_not_called()
+
+    def test_url_fetch_fail_expired(self, *_):
+        """Test expired cache entry removal when fetch fails."""
+        cache = self.source_cache(
+            self.url, ip={'10.0.0.1': self.now}, refresh=self.now - 1000
+        )
+        entry, warning, verbose = self.run_get(
+            url=self.url, cache=cache, content=None
+        )
+        self.assertFalse(entry['ip'])
+        self.assertTrue(entry['dirty'])
+        warning.assert_not_called()
+        verbose.assert_not_called()
+
+    def test_file_source(self, *_):
+        """Test local file source is read with get_file()."""
+        url = './test.iplist'
+        cache = self.source_cache(url, ip={'10.0.0.1': self.now})
+        options = foomuuri.IPListSourceOptions()
+        options.timeout = 1000
+        with (
+            unittest.mock.patch(
+                'foomuuri.get_file', return_value='10.0.0.7\n'
+            ) as get_file,
+            unittest.mock.patch('foomuuri.get_url') as get_url,
+            unittest.mock.patch('foomuuri.warning') as warning,
+            unittest.mock.patch('foomuuri.verbose') as verbose,
+        ):
+            foomuuri.get_url_or_file(url, options, cache)
+        entry = cache[url]
+        self.assertIn('10.0.0.7', entry['ip'])
+        self.assertTrue(entry['dirty'])
+        get_file.assert_called_once_with(url)
+        get_url.assert_not_called()
+        warning.assert_not_called()
+        verbose.assert_called_once_with(
+            f'Iplist content for "{url}" refreshed, 1 entries'
+        )
+
+    def test_set_single_missing_ok_empty(self, *_):
+        """Test warning and rc 0 for |missing-ok source with empty content."""
+        cache = self.source_cache(self.url_missing_ok)
+        ret, warning, fail, verbose = self.run_output(
+            sources=[self.url_missing_ok],
+            cache=cache,
+            setname='@foo',
+        )
+        self.assertEqual(ret, 0)
+        warning.assert_called_once_with('Iplist "@foo" is empty')
+        fail.assert_not_called()
+        verbose.assert_not_called()
+
+    def test_set_single_no_missing_ok_empty(self, *_):
+        """Test fail and rc 2 for source with empty content."""
+        cache = self.source_cache(self.url)
+        ret, warning, fail, verbose = self.run_output(
+            sources=[self.url],
+            cache=cache,
+            setname='@foo',
+        )
+        self.assertEqual(ret, 2)
+        fail.assert_called_once_with('Iplist "@foo" is empty', False)
+        warning.assert_not_called()
+        verbose.assert_not_called()
+
+    def test_set_mixed_sources_empty(self, *_):
+        """Test fail and rc 2 for mixed sources with empty content."""
+        optional = self.url_missing_ok
+        required = 'https://required.example/list'
+        cache = self.source_cache(optional, required)
+        ret, warning, fail, verbose = self.run_output(
+            sources=[optional, required],
+            cache=cache,
+            setname='@foo',
+        )
+        self.assertEqual(ret, 2)
+        fail.assert_called_once_with('Iplist "@foo" is empty', False)
+        warning.assert_not_called()
+        verbose.assert_not_called()
+
+    def test_set_clean_soft(self, *_):
+        """Test verbose skip update message with --soft (force<0)."""
+        cache = self.source_cache(self.url)
+        ret, warning, fail, verbose = self.run_output(
+            sources=[self.url],
+            cache=cache,
+            setname='@foo',
+            force=-1,
+        )
+        self.assertEqual(ret, 0)
+        warning.assert_not_called()
+        fail.assert_not_called()
+        verbose.assert_called_once_with(
+            'Iplist "@foo" is clean, skipping update'
+        )
+
+    def test_set_dirty_soft_updates(self, *_):
+        """Test dirty cache updates with --soft (force<0)."""
+        cache = self.source_cache(self.url, ip={'10.0.0.1': self.now})
+        cache[self.url]['dirty'] = True
+        ret, warning, fail, verbose = self.run_output(
+            sources=[self.url],
+            cache=cache,
+            setname='@foo',
+            force=-1,
+        )
+        self.assertEqual(ret, 0)
+        warning.assert_not_called()
+        fail.assert_not_called()
+        verbose.assert_called_once_with('Updating iplist "@foo", 1 entries')
+
+    def test_set_nonempty_updates(self, *_):
+        """Test verbose update message for non-empty set."""
+        cache = self.source_cache(self.url, ip={'10.0.0.1': self.now})
+        ret, warning, fail, verbose = self.run_output(
+            sources=[self.url],
+            cache=cache,
+            setname='@foo',
+        )
+        self.assertEqual(ret, 0)
+        warning.assert_not_called()
+        fail.assert_not_called()
+        verbose.assert_called_once_with('Updating iplist "@foo", 1 entries')

--- a/src/tests/test_iplist_resolve.py
+++ b/src/tests/test_iplist_resolve.py
@@ -1,0 +1,189 @@
+"""Test iplist resolve_all_hostnames().
+
+Cover hostname resolution, iplist cache management and user interaction
+behaviour.
+"""
+# pylint: disable=invalid-name,import-error
+
+import copy
+import time
+import unittest.mock
+
+import foomuuri
+from foomuuri import INTERNAL as BASE_INTERNAL
+
+
+@unittest.mock.patch(
+    'foomuuri.INTERNAL', new_callable=lambda: copy.deepcopy(BASE_INTERNAL)
+)
+class TestResolveHostnames(unittest.TestCase):
+    """Test resolve_all_hostnames() behaviour."""
+
+    def setUp(self):
+        """Prepare test fixtures."""
+        self.now = int(time.time())
+
+    @staticmethod
+    def source_options(timeout=1000):
+        """Return IPListSourceOptions instance."""
+        options = foomuuri.IPListSourceOptions()
+        options.timeout = timeout
+        return options
+
+    @staticmethod
+    def run_resolve(resolve, cache, addresses=None, force=0):
+        """Call resolve_all_hostnames() with mocked helpers."""
+        # addresses: dict, hostname -> set of resolved IPs
+        if addresses is None:
+            addresses = {}
+        foomuuri.INTERNAL.force = force
+        with (
+            unittest.mock.patch(
+                'foomuuri.resolve_one_hostname',
+                side_effect=lambda name: addresses.get(name, set()),
+            ),
+            unittest.mock.patch('foomuuri.warning') as warning,
+            unittest.mock.patch('foomuuri.verbose') as verbose,
+        ):
+            foomuuri.resolve_all_hostnames(resolve, cache)
+        return cache, warning, verbose
+
+    def test_resolve_hostname_ok(self, *_):
+        """Test hostname resolution and IP address caching."""
+        cache, warning, verbose = self.run_resolve(
+            {'foo.bar': self.source_options()},
+            cache={},
+            addresses={'foo.bar': {'10.0.0.5'}},
+        )
+        entry = cache['foo.bar']
+        self.assertEqual(entry['ip']['10.0.0.5'], entry['refresh'] + 1000)
+        self.assertTrue(entry['dirty'])
+        warning.assert_not_called()
+        verbose.assert_any_call('Hostname "foo.bar" resolved to: 10.0.0.5')
+
+    def test_resolve_hostname_expire_forever(self, *_):
+        """Test very large timeout sets expiry to "forever"."""
+        cache, _, _ = self.run_resolve(
+            {'foo.bar': self.source_options(foomuuri.INTERNAL.expire_max + 1)},
+            cache={},
+            addresses={'foo.bar': {'10.0.0.9'}},
+        )
+        self.assertEqual(
+            cache['foo.bar']['ip']['10.0.0.9'],
+            foomuuri.INTERNAL.expire_forever,
+        )
+
+    def test_resolve_hostname_failed_warns(self, *_):
+        """Test warning when hostname resolves to nothing."""
+        cache, warning, _ = self.run_resolve(
+            {'foo.bar': self.source_options()}, cache={}
+        )
+        self.assertNotIn('foo.bar', cache)
+        warning.assert_called_once_with(
+            'No IP address found for hostname "foo.bar" in iplist'
+        )
+
+    def test_resolve_hostname_failed_missing_ok(self, *_):
+        """Test no warning when |missing-ok hostname resolves to nothing."""
+        cache, warning, _ = self.run_resolve(
+            {'foo.bar|missing-ok': self.source_options()}, cache={}
+        )
+        self.assertNotIn('foo.bar|missing-ok', cache)
+        warning.assert_not_called()
+
+    def test_resolve_hostname_appends(self, *_):
+        """Test hostname resolution appends IP addresses to cache."""
+        cache = {
+            'foo.bar|missing-ok': {
+                'ip': {'10.0.0.1': 0},
+                'dirty': False,
+                'refresh': self.now,
+            }
+        }
+        cache, _, _ = self.run_resolve(
+            {'foo.bar|missing-ok': self.source_options()},
+            cache=cache,
+            addresses={'foo.bar|missing-ok': {'10.0.0.9'}},
+        )
+        self.assertIn('10.0.0.1', cache['foo.bar|missing-ok']['ip'])
+        self.assertIn('10.0.0.9', cache['foo.bar|missing-ok']['ip'])
+        self.assertTrue(cache['foo.bar|missing-ok']['dirty'])
+
+    def test_resolve_hostname_expired_cleared(self, *_):
+        """Test resolution clears expired cached IP addresses."""
+        cache = {
+            'foo.bar': {
+                'ip': {'10.0.0.1': 0},
+                'dirty': False,
+                'refresh': self.now - 2000,
+            }
+        }
+        cache, _, _ = self.run_resolve(
+            {'foo.bar': self.source_options(timeout=1000)},
+            cache=cache,
+            addresses={'foo.bar': {'10.0.0.9'}},
+        )
+        self.assertNotIn('10.0.0.1', cache['foo.bar']['ip'])
+        self.assertIn('10.0.0.9', cache['foo.bar']['ip'])
+
+    def test_resolve_hostname_expired_soft_reresolves(self, *_):
+        """Test --soft (force<0) mode re-resolves expired cache entry."""
+        cache = {
+            'foo.bar': {
+                'ip': {'10.0.0.1': 0},
+                'dirty': False,
+                'refresh': self.now - 2000,
+            }
+        }
+        cache, warning, verbose = self.run_resolve(
+            {'foo.bar': self.source_options(timeout=1000)},
+            cache=cache,
+            addresses={'foo.bar': {'10.0.0.9'}},
+            force=-1,
+        )
+        self.assertNotIn('10.0.0.1', cache['foo.bar']['ip'])
+        self.assertIn('10.0.0.9', cache['foo.bar']['ip'])
+        warning.assert_not_called()
+        verbose.assert_any_call('Hostname "foo.bar" resolved to: 10.0.0.9')
+
+    def test_resolve_hostname_cached_soft(self, *_):
+        """Test no resolution with fresh cache and --soft (force<0)."""
+        cache = {
+            'foo.bar|missing-ok': {
+                'ip': {'10.0.0.1': 0},
+                'dirty': False,
+                'refresh': self.now,
+            }
+        }
+        cache, warning, verbose = self.run_resolve(
+            {'foo.bar|missing-ok': self.source_options()},
+            cache=cache,
+            addresses={'foo.bar|missing-ok': {'10.0.0.9'}},
+            force=-1,
+        )
+        self.assertEqual(cache['foo.bar|missing-ok']['ip'], {'10.0.0.1': 0})
+        verbose.assert_called_once_with('Using cached value for "foo.bar"')
+        warning.assert_not_called()
+
+    def test_resolve_hostnames_all_cached_no_lookup(self, *_):
+        """Test no resolution when all hostnames cached in soft mode."""
+        names = ('foo.bar', 'baz.qux')
+        cache = {
+            name: {
+                'ip': {'10.0.0.1': 0},
+                'dirty': False,
+                'refresh': self.now,
+            }
+            for name in names
+        }
+        snapshot = copy.deepcopy(cache)
+        cache, warning, verbose = self.run_resolve(
+            {name: self.source_options() for name in names},
+            cache=cache,
+            addresses={name: {'10.0.0.9'} for name in names},
+            force=-1,
+        )
+        self.assertEqual(cache, snapshot)
+        warning.assert_not_called()
+        for call in verbose.call_args_list:
+            self.assertNotIn('DNS lookup for:', call.args[0])


### PR DESCRIPTION
An attempt to test most important bits of iplist update via `get_url_or_file()` and `resolve_all_hostnames()`:

- Cache values addition, replacement, expiration
- Interactive messages (fail, warn, verbose)
- Return codes
- Some combinations of `--soft` with the above